### PR TITLE
Additional RF information options for EPBs

### DIFF
--- a/draft-tuexen-opsawg-pcapng.xml
+++ b/draft-tuexen-opsawg-pcapng.xml
@@ -1269,6 +1269,11 @@ Section Header
           <c>4</c>
           <c>8</c>
           <c>no</c>
+
+          <c>epb_rssi</c>
+          <c>5</c>
+          <c>6</c>
+          <c>yes</c>
         </texttable>
 
         <t>
@@ -1305,6 +1310,13 @@ Section Header
             this packet and the start of the capture process.</t>
 
             <t>Example: '0'.</t>
+
+            <t hangText="epb_rssi:"><vspace blankLines="0"/>The
+            epb_rssi option represents an antenna-rssi pair for the received
+            packet. This consists of a unsigned 16 bit integer value for the antenna 
+            index, and a 32-bit floating point RSSI in dBm.</t>
+
+            <t>Example: '01 00 00 00 92 c2' for Antenna 1, -73.0 dBm.</t>
 
           </list>
         </t>


### PR DESCRIPTION
Following from #48, this PR is to add per-packet options for capture information to the EPB, alongside the per-interface options introduced in #51.

This PR is a work in progress and requires further discussion, opening now so there is a clear delineation between this and #51.

## TODO
- What RF options do we want?
- How do we want to represent them?
  - I am in favour of 32-bit IEEE-754 floats where sensible, rather than defining our own fixed-point approximations (and we have already accepted the inclusion of this for location information)

## Options
- [x] RSSI per antenna
